### PR TITLE
Fix GCC 8 warnings

### DIFF
--- a/common/nng/socket.cpp
+++ b/common/nng/socket.cpp
@@ -231,7 +231,7 @@ std::unique_ptr<Message> SubSocket::Receive(int flags)
 	if (rc != 0)
 	{
 		MAPF_ERR("Can't allocate buffer for message");
-		return false;
+		return nullptr;
 	}
 	std::string topic = std::string((char*)buf, 0, Message::kMaxTopicSize);
 	int nbytes = size - Message::kMaxTopicSize;

--- a/transport/ieee1905_transport/ieee1905_transport_network.cpp
+++ b/transport/ieee1905_transport/ieee1905_transport_network.cpp
@@ -16,6 +16,7 @@
 #include <linux/filter.h>
 #include <sys/ioctl.h>
 #include <sys/socket.h>
+#include <sys/uio.h>
 #include <iomanip>
 
 namespace mapf {


### PR DESCRIPTION
Building on PC with GCC 8 triggered a few warnings. These two commits fix them.