### PR TITLE
easylogging: add S_IROTH to elpp file permissions

### DIFF
--- a/external/easylogging/easylogging++.h
+++ b/external/easylogging/easylogging++.h
@@ -222,7 +222,7 @@ ELPP_INTERNAL_DEBUGGING_OUT_INFO << ELPP_INTERNAL_DEBUGGING_MSG(internalInfoStre
 #define ELPP_UNUSED(x) (void)x
 #if ELPP_OS_UNIX
 // Log file permissions for unix-based systems
-#  define ELPP_LOG_PERMS S_IRUSR | S_IWUSR | S_IXUSR | S_IWGRP | S_IRGRP | S_IXGRP | S_IWOTH | S_IXOTH
+#  define ELPP_LOG_PERMS S_IRUSR | S_IWUSR | S_IXUSR | S_IWGRP | S_IRGRP | S_IXGRP | S_IWOTH | S_IXOTH | S_IROTH
 #endif  // ELPP_OS_UNIX
 #if defined(ELPP_AS_DLL) && ELPP_COMPILER_MSVC
 #  if defined(ELPP_EXPORT_SYMBOLS)


### PR DESCRIPTION
Add S_IROTH to file permissions so that created folders and log files
can be read by other users. Original permissions have write permissions
for other, so the only reason not to give read permissions to others is
to prevent log files read by attackers which may contain sensitive data.
But even in this case the better solution is to simply _not_ store
sensitive data in log files.

Signed-off-by: Tomer Eliyahu <tomer.b.eliyahu@intel.com>